### PR TITLE
chore: add project config, roadmap, and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Description
+
+<!-- What went wrong? -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What should have happened? -->
+
+## Actual Behavior
+
+<!-- What actually happened? -->
+
+## Environment
+
+- Device/Emulator:
+- Android version:
+- App version:
+
+## Screenshots
+
+<!-- If applicable -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Propose a new feature or enhancement
+labels: feature
+---
+
+## Description
+
+<!-- What should this feature do? -->
+
+## Motivation
+
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Acceptance Criteria
+
+- [ ] <!-- Criterion 1 -->
+- [ ] <!-- Criterion 2 -->
+- [ ] <!-- Criterion 3 -->
+
+## Design
+
+<!-- Link to Figma frame, screenshot, or describe the expected UI (if applicable) -->
+
+## Technical Notes
+
+<!-- Any implementation considerations, dependencies, or module placement -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,17 @@
+---
+name: Task
+about: General engineering task
+labels: ""
+---
+
+## Description
+
+<!-- What needs to be done? -->
+
+## Details
+
+<!-- Implementation details, links, references -->
+
+## Done When
+
+- [ ] <!-- Completion criterion -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+Closes #<!-- issue number -->
+
+## Changes
+
+-
+
+## Screenshots
+
+<!-- If UI changes, before/after screenshots -->
+
+## Testing
+
+- [ ] Unit tests pass (`./gradlew test`)
+- [ ] Lint passes (`./gradlew lint`)
+- [ ] Debug build succeeds (`./gradlew assembleDebug`)
+- [ ] Manually verified on emulator/device
+
+## Checklist
+
+- [ ] Code follows project conventions (see CLAUDE.md)
+- [ ] No hardcoded strings (use `strings.xml`)
+- [ ] `@Preview` added for new composables
+- [ ] ViewModel state exposed as `StateFlow`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# ShowcaseApp — Project Configuration
+
+## Overview
+
+Android app demonstrating best engineering practices for potential stakeholders (HRs, engineering managers). Built using a CI/CD pipeline with AI agents handling code generation, PR reviews, and task management.
+
+- **Package:** `com.prokopov.showcaseapp`
+- **Repo:** `git@github.com:AProkopov/ShowcaseApp.git`
+- **Branch:** `master`
+
+## Architecture
+
+- **Modules:** Multi-module (planned — currently single `:app` module)
+  - `app/` — entry point only
+  - `core/core-ui/` — design system, theme, shared composables
+  - `core/core-data/` — repository interfaces, domain models
+  - `core/core-network/` — Retrofit/Ktor, API definitions
+  - `core/core-testing/` — test utilities, fakes
+  - `feature/feature-home/` — home/dashboard screen
+  - `feature/feature-settings/` — settings with DataStore
+  - `feature/feature-showcase/` — catalog of pattern demos
+  - `build-logic/convention/` — shared Gradle convention plugins
+- **Navigation:** Compose Navigation with type-safe routes, bottom nav (Home, Showcase, Settings)
+- **DI:** Hilt across all modules
+
+## Build Commands
+
+```bash
+./gradlew assembleDebug       # Build debug APK
+./gradlew test                # Run unit tests
+./gradlew lint                # Run Android Lint
+./gradlew detekt              # Run Detekt static analysis (after Phase 2)
+./gradlew ktlintCheck         # Run ktlint formatting check (after Phase 2)
+```
+
+## Current Dependencies
+
+From `gradle/libs.versions.toml`:
+- AGP 8.11.2, Kotlin 2.0.21
+- Compose BOM 2024.09.00, Material3
+- AndroidX Core KTX 1.10.1, Lifecycle 2.6.1, Activity Compose 1.8.0
+- JUnit 4.13.2, Espresso 3.5.1
+
+## Workflow
+
+All changes go through: branch -> code -> PR -> CI checks -> review -> squash-merge to master.
+
+GitHub Projects board tracks all work (link TBD after Phase 1 setup).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,62 @@
+# ShowcaseApp + AI Infrastructure Roadmap
+
+Started: 2026-04-04
+
+## Phase 0: Foundation
+- [x] Install `gh` CLI
+- [x] Create global `~/CLAUDE.md`
+- [x] Create project `ShowcaseApp/CLAUDE.md`
+- [x] Set up Claude memory system
+- [x] Create this roadmap (repo + memory)
+- [x] Authenticate `gh` CLI (`gh auth login`)
+
+## Phase 1: GitHub Workflow
+- [x] Configure branch protection on `master`
+- [ ] Create GitHub Projects board (Backlog -> Ready -> In Progress -> In Review -> Done)
+- [x] Create labels: `infra`, `feature`, `bug`, `ci-cd`, `agent`, `architecture`, `documentation`
+- [x] Create issue templates (feature request, bug report, task)
+- [x] Create PR template
+- [x] Create milestone issues for Phases 2-6 (#1-#5)
+- [ ] Verify end-to-end: branch -> PR -> review -> merge
+
+## Phase 2: CI/CD Pipeline
+- [ ] Android build workflow (assembleDebug, test, lint)
+- [ ] Add Detekt + ktlint for code quality
+- [ ] Code quality workflow
+- [ ] Wire status checks to branch protection
+- [ ] README with build badge
+
+## Phase 3: First AI Agents
+- [ ] Create `android-dev` plugin scaffold
+- [ ] Build `android-code-writer` agent
+- [ ] Build `android-pr-reviewer` agent
+- [ ] Build `/new-feature` command
+- [ ] Build `/review-pr` command
+- [ ] Test end-to-end: `/new-feature` produces a compilable PR with review
+
+## Phase 4: ShowcaseApp Architecture (interleave with Phase 5)
+- [ ] Multi-module setup with convention plugins (`build-logic/`)
+- [ ] Hilt DI across modules
+- [ ] Type-safe Compose Navigation + bottom nav
+- [ ] Feature: Design system (core-ui)
+- [ ] Feature: Home screen
+- [ ] Feature: Settings (theme toggle, DataStore)
+- [ ] Feature: Showcase catalog
+- [ ] Feature: Network layer (GitHub API)
+- [ ] Testing: ViewModel unit tests, Compose UI tests, fakes
+
+## Phase 5: Advanced Agents (interleave with Phase 4)
+- [ ] Auto-merger agent
+- [ ] Task tracker agent
+- [ ] Design-to-code agent (Figma screenshots -> Compose)
+- [ ] `/sprint` orchestrator command
+
+## Phase 6: Integration & Polish
+- [ ] Extract `android-dev` plugin to separate repo
+- [ ] ShowcaseApp polish (icon, splash, tech stack screen, process screen)
+- [ ] Create template repository
+- [ ] Retrospective + CLAUDE.md refinement
+
+---
+
+**Estimated total: 3-5 weeks part-time**


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with project-specific conventions (architecture, build commands, dependencies)
- Add `ROADMAP.md` tracking progress across all 6 phases
- Add issue templates: feature request, bug report, task
- Add PR template with testing checklist

## Test plan

- [x] Files committed and pushed
- [ ] PR template renders correctly on this PR
- [ ] Issue templates visible at github.com/AProkopov/ShowcaseApp/issues/new/choose

🤖 Generated with [Claude Code](https://claude.com/claude-code)